### PR TITLE
feat(apdu): add ConnectionLost variant to Error enum

### DIFF
--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -30,6 +30,8 @@ pub enum Error {
     IncorrectSignature(String),
     #[error("UnknownCardType: {0}")]
     UnknownCardType(String),
+    #[error("ConnectionLost: {0}")]
+    ConnectionLost(String),
 
     #[cfg(feature = "pcsc")]
     #[error("PcSc: {0}")]


### PR DESCRIPTION
### Description

- When a phone loses NFC contact with a SATSCARD or TAPSIGNER mid-command, the transport layer needs to report this through apdu::Error. 
- Currently there is no variant for it, so Cove is forced to map it to apdu::Error::CkTap(CkTapError::BadArguments) - which is wrong because a connection drop is not a bad argument. 
- This makes it impossible to tell connection drops apart from actual protocol errors, breaking retry logic and user-facing error messages.
- This PR fixes this by introducing ConnectionLost variant to Error Enum

### Notes to the reviewers

- bitcoinppl/cove#625 adds type-safe connection error handling to Cove's NFC tap-card integration. That PR needs this variant so ConnectionLost can pass cleanly through apdu::Error without being erased to BadArguments or requiring a sentinel workaround.

### Changelog

- Add `ConnectionLost(String)` to `apdu::Error`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for connection loss scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->